### PR TITLE
Add racial profanity neutralizer

### DIFF
--- a/script.js
+++ b/script.js
@@ -78,6 +78,13 @@ function handleText(textNode)
     v = v.replace(/canadian person/g, " person ");
     v = v.replace(/Black woman |Black man /g, " Person ");
     v = v.replace(/black woman |black man /g, " person ");
+    
+    //racial profanity neutralizer
+    v = v.replace(/nigger/g, " someone who annoys you "); // "oh, nagger...."
+    v = v.replace(/spearchucker/g, " olympics contestant ");
+    v = v.replace(/currynigger/g, " microsoft support official ");
+    v = v.replace(/snownigger/g, " proud viking ");
+    v = v.replace(/sandnigger/g, " bomb enthousiast ");
 
     textNode.nodeValue = v;
 }


### PR DESCRIPTION
Racial profanity is especially big on sites like 4chan, e.g. the /b/ and the /pol/  board. With this extra filter you can laugh your ass of instead of being triggered.

"I hate sandnigger immmigration! A sandnigger is even worse than a regular nigger. At least a spearchuckers steals your shit, not blow it up"

becomes

"I hate bomb enthousiast immigration! A bomb enthousiast is even worse than a regular someone who annoys you. At least a olympics contestant steals your shit, not blow it up"

And 

"What's worse /pol/? An inbred snownigger, or a stinking currynigger?"

becomes

"What's worse /pol/? An inbred proud viking, or a stinking microsoft support official?"
